### PR TITLE
Docs: Correct algorithm READMEs to English

### DIFF
--- a/Actor-Critic(AC)_boltzmann/readme.md
+++ b/Actor-Critic(AC)_boltzmann/readme.md
@@ -6,3 +6,53 @@ The AC algorithm consists of two core components:
 Actor: Responsible for learning and representing the policy function π(a|s). The Actor network outputs the probability distribution of action a based on the current state s.
 Critic: Responsible for learning and representing the state value function V(s) or action value function Q(s,a). The Critic network predicts the expected value of cumulative discounted rewards based on the current state s and the action a taken.
 The Actor network and Critic network learn interactively and optimize step by step, with the Critic network providing feedback signals to guide the Actor network to adjust the policy in a direction that can achieve higher rewards. This coupled learning approach allows the AC algorithm to maintain the convergence of policy gradient algorithms while significantly improving learning efficiency.
+
+### Application in Traffic Signal Control
+
+In Traffic Signal Control (TSC), the Actor-Critic (AC) method is employed to enable traffic lights (as agents) to learn optimal timing strategies.
+
+*   **State (S)**: Typically includes real-time traffic information at an intersection, such as:
+    *   Queue length of vehicles in each approach lane.
+    *   Number of vehicles detected by sensors.
+    *   Average waiting time of vehicles.
+    *   Current signal phase.
+    *   Elapsed time in the current phase.
+
+*   **Action (A)**: The agent's action is usually to select the next signal phase to switch to, or to decide whether to extend the current phase. For instance, at a typical four-phase intersection, an action could be choosing one of the four phases.
+
+*   **Reward (R)**: The design of the reward function is crucial and directly impacts the agent's learning effectiveness. The goal is generally to minimize congestion. Common reward functions include:
+    *   Negative cumulative vehicle waiting time: $-\sum w_i$ (where $w_i$ is the waiting time of each vehicle).
+    *   Negative cumulative queue length: $-\sum q_l$ (where $q_l$ is the queue length of each lane).
+    *   Change in system throughput: e.g., the number of vehicles passing through the intersection per unit time.
+    *   Reduction in intersection pressure, where pressure can be defined as the difference between the number of incoming and outgoing vehicles.
+
+*   **Actor Network**:
+    *   **Input**: Current state S.
+    *   **Output**: A probability distribution over actions $\pi(A|S; 	heta_{	ext{actor}})$. For example, if the action is to select the next phase, the Actor outputs the probability of switching to each possible phase.
+    *   **Objective**: To learn a policy that maximizes cumulative rewards.
+
+*   **Critic Network**:
+    *   **Input**: Current state S (and sometimes action A, depending on whether the Critic estimates the state-value function V(S) or the state-action value function Q(S,A)).
+    *   **Output**: An evaluation of the value of the current state (or state-action pair), $V(S; 	heta_{	ext{critic}})$ or $Q(S,A; 	heta_{	ext{critic}})$۔ This value represents the expected cumulative reward obtainable from the current state by following the Actor's policy.
+    *   **Objective**: To accurately evaluate the quality of the policy chosen by the Actor, typically updated by minimizing the Temporal Difference (TD) error: $R_t + \gamma V(S_{t+1}) - V(S_t)$.
+
+*   **Network Structure**: Both Actor and Critic often use Deep Neural Networks (DNNs), such as Multi-Layer Perceptrons (MLPs). The input layer corresponds to state features, followed by several hidden layers, and an output layer corresponding to the policy (Actor) or value (Critic).
+
+### Boltzmann Exploration
+
+This AC implementation specifically mentions the use of **Boltzmann Exploration**. This is a probability-based exploration strategy used to balance exploration (trying new actions) and exploitation (choosing the currently known best action) during the learning process.
+
+The probability of selecting action $a$ in state $s$, $\pi(a|s)$, is typically given by the Boltzmann (or Softmax) distribution:
+
+$$
+\pi(a|s) = rac{e^{Q(s,a)/	au}}{\sum_{b \in A} e^{Q(s,b)/	au}}
+$$
+
+Where:
+*   $Q(s,a)$ is the agent's estimate of the value of taking action $a$ in state $s$ (often derived from the Actor's output or combined with the Critic's evaluation).
+*   $	au$ (tau) is a positive parameter called "temperature."
+    *   When $	au$ is high, the probabilities of selecting any action become more uniform, and the agent tends to explore more.
+    *   When $	au$ is low, actions with higher $Q(s,a)$ values have a much greater probability of being selected, and the agent tends to exploit its learned optimal policy.
+    *   Often, $	au$ is gradually decreased (annealed) as training progresses, encouraging more exploration in the early stages and more exploitation later.
+
+Compared to strategies like $\epsilon$-greedy, Boltzmann exploration adjusts selection probabilities based on the value estimates of actions, rather than choosing non-optimal actions completely at random, which can be more efficient in some scenarios.

--- a/DDPG/readme.md
+++ b/DDPG/readme.md
@@ -1,1 +1,118 @@
-# DDPG
+# DDPG (Deep Deterministic Policy Gradient)
+
+## 1. Introduction
+
+Deep Deterministic Policy Gradient (DDPG) is a model-free, off-policy Actor-Critic algorithm for reinforcement learning in continuous action spaces. It combines ideas from Deep Q-Networks (DQN) and Deterministic Policy Gradients (DPG), enabling effective policy learning in environments with continuous actions.
+
+The core idea of DDPG is to concurrently learn a Q-function (Critic) and a policy (Actor). The Critic evaluates the quality (Q-value) of taking a certain action in a given state, while the Actor learns a deterministic policy that outputs the optimal action based on the Critic's evaluation.
+
+## 2. Method
+
+DDPG involves two main neural networks: an Actor network and a Critic network. Additionally, to stabilize the training process, DDPG maintains corresponding target networks for both.
+
+*   **Actor Network ($\mu(S; 	heta^\mu)$)**:
+    *   **Role**: Learns a deterministic policy that maps a state $S$ directly to a specific action $A$.
+    *   **Input**: State $S$.
+    *   **Output**: A deterministic action $A = \mu(S; 	heta^\mu)$.
+    *   **Update**: The Actor network's parameters $	heta^\mu$ are updated by maximizing the Q-value provided by the Critic network, using a policy gradient method. The objective is to make the Actor output actions that receive higher Q-values from the Critic. The gradient of the objective function $J$ can be approximated as:
+        $$
+
+abla_{	heta^\mu} J pprox \mathbb{E}_{s_t \sim \mathcal{D}} \left[
+abla_a Q(s, a; 	heta^Q)|_{s=s_t, a=\mu(s_t)}
+abla_{	heta^\mu} \mu(s; 	heta^\mu)|_{s=s_t} ight]
+        $$
+        Simply put, the Actor network is updated in the direction that increases the Q-values.
+
+*   **Critic Network ($Q(S, A; 	heta^Q)$)**:
+    *   **Role**: Learns an action-value function (Q-function) that estimates the expected return for taking action $A$ in state $S$.
+    *   **Input**: State $S$ and Action $A$.
+    *   **Output**: Q-value $Q(S, A; 	heta^Q)$.
+    *   **Update**: The Critic network's parameters $	heta^Q$ are updated by minimizing the Mean Squared Bellman Error (MSBE), similar to Q-Learning. Its loss function is:
+        $$
+        L(	heta^Q) = \mathbb{E}_{(s_t, a_t, r_t, s_{t+1}) \sim \mathcal{D}} \left[ \left( Q(s_t, a_t; 	heta^Q) - y_t ight)^2 ight]
+        $$
+        where $y_t$ is the target Q-value, calculated as:
+        $$
+        y_t = r_t + \gamma Q'(s_{t+1}, \mu'(s_{t+1}; 	heta^{\mu'}); 	heta^{Q'})
+        $$
+        $Q'$ and $\mu'$ are the target Critic network and target Actor network, respectively. $\mathcal{D}$ is the experience replay buffer.
+
+*   **Target Networks**:
+    *   DDPG maintains a target network for both the Actor ($\mu'(S; 	heta^{\mu'})$) and the Critic ($Q'(S, A; 	heta^{Q'})$).
+    *   The parameters of the target networks are periodically and slowly updated from the main network parameters using "soft updates" (Polyak averaging):
+        $$
+		heta' \leftarrow 	au 	heta + (1-	au) 	heta'
+        $$
+        where $	au \ll 1$ (e.g., $	au = 0.001$ or $0.005$). This makes the calculation of target Q-values more stable, thus improving the stability of the overall learning process.
+
+*   **Experience Replay**:
+    *   DDPG uses an experience replay buffer $\mathcal{D}$ to store transitions $(s_t, a_t, r_t, s_{t+1}, 	ext{done})$ generated from the agent's interaction with the environment.
+    *   During training, mini-batches of experience are randomly sampled from this buffer to update the Actor and Critic networks. This helps to break correlations between data samples and improves learning efficiency and stability.
+
+*   **Exploration**:
+    *   Since DDPG learns a deterministic policy, sufficient exploration is crucial. This is typically achieved by adding noise to the Actor's output actions during training.
+    *   Commonly used noise includes time-correlated Ornstein-Uhlenbeck (OU) noise or simpler zero-mean Gaussian noise.
+    *   $A_t = \mu(S_t; 	heta^\mu) + \mathcal{N}_t$
+    *   During testing or evaluation, no noise is added, and the deterministic actions from the Actor network are used directly.
+
+## 3. Application in Traffic Signal Control
+
+DDPG is well-suited for traffic signal control problems where the action space is continuous, such as directly controlling the duration of green lights.
+
+*   **State (S)**: Similar to other RL algorithms, can include:
+    *   Queue lengths and waiting times for each lane.
+    *   Detector data (vehicle counts, occupancy).
+    *   Current signal phase and elapsed time in that phase.
+
+*   **Action (A)**: DDPG's main advantage lies in handling continuous actions. In traffic control, actions could be:
+    *   **Direct control of green light duration for the next phase**: e.g., outputting a continuous value within a [min, max] range representing the duration.
+    *   **Control of parameters for phase switching thresholds**: e.g., adjusting a continuous parameter that determines when to switch phases.
+    *   Note: If DDPG is used for selecting discrete phases, its output needs additional processing (e.g., applying argmax to multiple output nodes, where each node represents a Q-value estimate for a phase—though this is closer to DQN's approach; DDPG's Actor typically outputs the action directly). If DDPG in this codebase is used for discrete phase selection, the design of its Actor's output layer and action selection mechanism warrants special attention.
+
+*   **Reward (R)**: Designed to optimize traffic flow, for example:
+    *   Minimizing average vehicle delay or waiting time.
+    *   Maximizing intersection throughput.
+    *   Reducing queue lengths.
+
+*   **Network Structure**:
+    *   Both Actor and Critic typically use Deep Neural Networks (DNNs), such as MLPs.
+    *   The Actor network's output layer activation function should be chosen based on the action range (e.g., `tanh` can scale output to [-1, 1], which can then be linearly transformed to the actual action range).
+    *   The Critic network takes state and action as input and outputs a single Q-value.
+
+## 4. Pseudocode Outline
+
+1.  Initialize Actor network $\mu(S; 	heta^\mu)$ and Critic network $Q(S, A; 	heta^Q)$ with parameters $	heta^\mu, 	heta^Q$.
+2.  Initialize target networks $\mu'$ and $Q'$ with parameters $	heta^{\mu'} \leftarrow 	heta^\mu$, $	heta^{Q'} \leftarrow 	heta^Q$.
+3.  Initialize experience replay buffer $\mathcal{D}$.
+4.  **Loop** for each episode:
+5.  &nbsp;&nbsp;&nbsp;&nbsp;Initialize exploration noise (e.g., OU noise or Gaussian noise).
+6.  &nbsp;&nbsp;&nbsp;&nbsp;Receive initial state $S_1$.
+7.  &nbsp;&nbsp;&nbsp;&nbsp;**Loop** for each step $t=1, T$:
+8.  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Select action $A_t = \mu(S_t; 	heta^\mu) + \mathcal{N}_t$ based on current policy and exploration noise.
+9.  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Execute action $A_t$, observe reward $R_t$ and new state $S_{t+1}$.
+10. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Store transition $(S_t, A_t, R_t, S_{t+1}, 	ext{done})$ in $\mathcal{D}$.
+11. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Randomly sample a mini-batch of $N$ transitions $(S_i, A_i, R_i, S_{i+1}, 	ext{done}_i)$ from $\mathcal{D}$.
+12. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Calculate target Q-values: $y_i = R_i + \gamma (1-	ext{done}_i) Q'(S_{i+1}, \mu'(S_{i+1}; 	heta^{\mu'}); 	heta^{Q'})$.
+13. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Update Critic network by minimizing the loss: $L = rac{1}{N} \sum_i (y_i - Q(S_i, A_i; 	heta^Q))^2$.
+14. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Update Actor network using the sampled policy gradient: $
+abla_{	heta^\mu} J pprox +rac{1}{N} \sum_i
+abla_A Q(S_i, A; 	heta^Q)|_{A=\mu(S_i)}
+abla_{	heta^\mu} \mu(S_i; 	heta^\mu)$.
+15. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Soft update target networks:
+    $$
+	heta^{Q'} \leftarrow 	au 	heta^Q + (1-	au) 	heta^{Q'}
+    $$
+    $$
+	heta^{\mu'} \leftarrow 	au 	heta^\mu + (1-	au) 	heta^{\mu'}
+    $$
+16. &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$S_t \leftarrow S_{t+1}$.
+17. &nbsp;&nbsp;&nbsp;&nbsp;**End** inner loop.
+18. **End** outer loop.
+
+## 5. Key Features
+
+*   **Off-Policy**: Can learn from old data in the experience replay buffer.
+*   **Deterministic Policy**: The Actor outputs deterministic actions rather than a probability distribution over actions.
+*   **Continuous Action Spaces**: Natively supports continuous action spaces, a key advantage over DQN.
+*   **Actor-Critic Architecture**: Simultaneously learns a policy (Actor) and a value function (Critic).
+*   **Target Networks and Soft Updates**: Enhance learning stability.

--- a/DuelingDDQN-DNN(D3QN)/readme.md
+++ b/DuelingDDQN-DNN(D3QN)/readme.md
@@ -1,1 +1,90 @@
-# DuelingDDQN-DNN(D3QN)
+# Dueling DDQN (D3QN) - Dueling Double Deep Q-Network
+
+## 1. Introduction
+
+Dueling Double Deep Q-Network (D3QN), sometimes referred to as Dueling DDQN, is a deep reinforcement learning algorithm that combines two significant improvements to the standard Deep Q-Network (DQN): the Dueling Network Architecture and Double Q-Learning. This combination aims to further enhance the performance and learning stability of value-based reinforcement learning methods in complex environments.
+
+*   **Dueling Network Architecture**: The core idea is to decompose the Q-value estimation into two parts: the state-value function $V(s)$ and the action-dependent advantage function $A(s,a)$. $V(s)$ represents the overall value of being in state $s$, while $A(s,a)$ represents the relative advantage of taking action $a$ in state $s$ compared to other actions. This decomposition helps the network learn which states are inherently valuable, without needing to ascertain the value of each action at that state.
+*   **Double Q-Learning**: This mechanism primarily addresses the common issue of Q-value overestimation in traditional Q-learning. By decoupling the action selection from the action evaluation step in the target Q-value calculation, DDQN achieves more accurate Q-value estimates, leading to higher quality policies.
+
+D3QN leverages both techniques simultaneously, expecting to achieve more precise Q-value estimations and more effective feature learning, thereby performing better in problems with high-dimensional state spaces and discrete action spaces, such as traffic signal control.
+
+## 2. Method
+
+The D3QN algorithm integrates the core mechanisms of Dueling Networks and Double DQN.
+
+*   **Network Structure (Dueling Architecture)**:
+    The neural network structure of D3QN is similar to that of Dueling DQN. The initial layers (often convolutional or fully connected) are shared for state feature extraction. Subsequently, the network splits into two independent streams:
+    1.  **Value Stream**: Outputs a scalar, the state value $V(s; 	heta, lpha)$, where $	heta$ are the shared network parameters and $lpha$ are the value stream's unique parameters.
+    2.  **Advantage Stream**: Outputs a vector, with dimensionality equal to the number of actions, representing the advantage $A(s, a; 	heta, eta)$ for each action, where $eta$ are the advantage stream's unique parameters.
+
+    The final Q-value is computed by combining the outputs of these two streams. To ensure the identifiability of $V(s)$ and $A(s,a)$ (i.e., to prevent a situation where $V$ increases by a constant and $A$ decreases by the same constant, leaving Q unchanged), one of the following aggregation methods is typically used:
+    $$
+    Q(s, a; 	heta, lpha, eta) = V(s; 	heta, lpha) + \left( A(s, a; 	heta, eta) - +rac{1}{|\mathcal{A}|} \sum_{a' \in \mathcal{A}} A(s, a'; 	heta, eta) ight)
+    $$
+    Alternatively, a common aggregation forces the advantage of the chosen optimal action to be zero:
+    $$
+    Q(s, a; 	heta, lpha, eta) = V(s; 	heta, lpha) + \left( A(s, a; 	heta, eta) - \max_{a' \in \mathcal{A}} A(s, a'; 	heta, eta) ight)
+    $$
+    Here, $\mathcal{A}$ is the set of all possible actions.
+
+*   **Q-Value Update with Double DQN Mechanism**:
+    D3QN employs the Double DQN approach to calculate the target Q-value, reducing overestimation. It uses two networks: the current main network $Q(\cdot; 	heta, lpha, eta)$ and a target network $Q'(\cdot; 	heta^-, lpha^-, eta^-)$.
+    The target Q-value $y_t$ is calculated as follows:
+    1.  Use the current **main network** $Q$ to select the best action $a^*$ in the next state $s_{t+1}$:
+        $$
+        a^* = rg\max_{a'} Q(s_{t+1}, a'; 	heta, lpha, eta)
+        $$
+    2.  Use the **target network** $Q'$ to evaluate this selected action $a^*$:
+        $$
+        y_t = r_t + \gamma (1-d) Q'(s_{t+1}, a^*; 	heta^-, lpha^-, eta^-)
+        $$
+    where $r_t$ is the immediate reward, $\gamma$ is the discount factor, and $d$ indicates if $s_{t+1}$ is a terminal state.
+
+*   **Loss Function**:
+    Similar to DQN and DDQN, the loss function for D3QN is the Mean Squared Error (MSE) between the predicted Q-values and the target Q-values:
+    $$
+    L(	heta, lpha, eta) = \mathbb{E}_{(s_t, a_t, r_t, s_{t+1}, d) \sim \mathcal{D}} \left[ \left( y_t - Q(s_t, a_t; 	heta, lpha, eta) ight)^2 ight]
+    $$
+    $\mathcal{D}$ is the experience replay buffer.
+
+*   **Experience Replay and Soft Target Updates**:
+    D3QN also uses experience replay to break data correlations and improve sample efficiency. The parameters of the target network ($	heta^-, lpha^-, eta^-$) are typically updated slowly from the main network parameters using Polyak averaging (soft updates):
+    $$
+	heta^- \leftarrow 	au 	heta + (1-	au) 	heta^-
+    $$
+    (This also applies to $lpha$ and $eta$), where $	au \ll 1$.
+
+## 3. Application in Traffic Signal Control
+
+D3QN is well-suited for traffic signal control problems involving complex state representations and discrete action choices.
+
+*   **State (S)**:
+    *   Image-based representation of the intersection (e.g., processed using a Convolutional Neural Network - CNN).
+    *   Detector-based features: queue lengths, vehicle counts, waiting times for each lane, current phase, elapsed time in the current phase, etc.
+
+*   **Action (A)**: A discrete set of actions, for example:
+    *   Selecting the next signal phase to activate.
+    *   Deciding to maintain the current phase or switch to a predetermined next phase.
+
+*   **Reward (R)**: Designed to optimize traffic efficiency, such as:
+    *   Reducing total or average waiting time.
+    *   Minimizing total queue length.
+    *   Maximizing vehicle throughput.
+    *   Reducing intersection pressure.
+
+*   **Network Structure**:
+    *   Typically includes shared layers for feature extraction (e.g., CNN or MLP).
+    *   This is followed by separate value and advantage streams, each potentially consisting of several fully connected layers.
+    *   Finally, an aggregation layer combines these streams to produce the Q-values.
+
+## 4. Key Features Summary
+
+*   **Combines advantages of Dueling DQN and Double DQN**:
+    *   Dueling architecture: More effectively learns state values without over-reliance on specific actions.
+    *   Double Q-learning mechanism: Reduces overestimation of Q-values, leading to more stable and accurate learning.
+*   **Off-Policy**: Can utilize experience replay.
+*   **Suitable for Discrete Action Spaces**.
+*   **Data Efficiency and Performance**: Often exhibits better sample efficiency and final performance compared to standalone DQN, DDQN, or Dueling DQN.
+
+D3QN, with its refined network architecture and optimized Q-value update mechanism, provides a powerful tool for tackling complex decision-making problems like dynamic traffic signal control.

--- a/Nash-DQN/readme.md
+++ b/Nash-DQN/readme.md
@@ -1,7 +1,75 @@
-# 步骤——把sarsa_ucb需要修改哪些文件
-1. 修改agent类中select_action函数、增加ucb函数、替换update_q_table_ql_single函数
-2. 修改yaml中参数部分
-3. 主函数根据sarsa流程进行修改
-4. 过程控制update_q_table函数修改
-5. init修改成对应的参数名称
-6. 存储数据中loss？
+# Nash-DQN (Nash Deep Q-Network)
+
+## 1. Introduction
+
+Nash Deep Q-Network (Nash-DQN) is a Multi-Agent Reinforcement Learning (MARL) algorithm that integrates the game theory concept of Nash Equilibrium with Deep Q-Networks (DQN). In MARL environments, especially when multiple agents coexist and their actions influence each other (e.g., multiple traffic signals controlling adjacent intersections), an agent's optimal decision depends not only on its own state but also on the strategies of other agents. Nash-DQN aims to find a stable joint policy in such interactive settings.
+
+Traditional single-agent DQN learns a Q-function $Q(s,a)$ to maximize its own cumulative reward. However, directly applying single-agent DQN in multi-agent systems can fail to converge to desirable solutions because the environment becomes non-stationary from each agent's perspective (as other agents' policies change during learning).
+
+The core idea of Nash-DQN is that, when updating Q-values or selecting actions, it considers a Nash Equilibrium point among all agents in the current state, rather than just maximizing an individual agent's Q-value. This means each agent's chosen action is its best response to the actions taken by other agents under the Nash Equilibrium.
+
+## 2. Method
+
+Nash-DQN extends the traditional DQN framework primarily by incorporating Nash Equilibrium computation into the Q-value update target calculation and/or the action selection phase.
+
+*   **Network Architecture**:
+    *   Each agent $i$ typically has its own Deep Q-Network $Q_i(s, a_i, \mathbf{a}_{-i}; 	heta_i)$ or $Q_i(s, \mathbf{a}; 	heta_i)$, where $s$ is the global state or local observation, $a_i$ is agent $i$'s action, $\mathbf{a}_{-i}$ is the joint action of all other agents, and $\mathbf{a}$ is the joint action of all agents.
+    *   The network takes the state as input and outputs the Q-values for each possible action $a_i$ of agent $i$. These Q-values may depend on the actions of other agents.
+
+*   **Q-Value Update**:
+    The standard DQN loss function for agent $i$ is:
+    $$
+    L(	heta_i) = \mathbb{E} \left[ (y_i - Q_i(s, a_i; 	heta_i))^2 ight]
+    $$
+    where the target value $y_i = r_i + \gamma \max_{a'} Q_i(s', a'; 	heta_i^-)$.
+
+    In Nash-DQN, the calculation of the target value $y_i$ is modified. Instead of simply maximizing over agent $i$'s action space, it is based on the Q-values at the Nash Equilibrium in the next state $s'$.
+    $$
+    y_i = r_i + \gamma 	ext{NashQ}_i(s', \mathbf{Q_1}(s', \cdot), \dots, \mathbf{Q_N}(s', \cdot); 	heta_1^-, \dots, 	heta_N^-)
+    $$
+    More specifically:
+    $$
+    y_i = r_i + \gamma Q_i(s', a_1^*, \dots, a_N^*; 	heta_i^-)
+    $$
+    where $(a_1^*, \dots, a_N^*)$ is the Nash Equilibrium joint action in state $s'$, calculated based on all agents' target Q-networks $Q_j(\cdot; 	heta_j^-)$. $	ext{NashQ}_i(s', \cdot)$ denotes the Nash Equilibrium Q-value for agent $i$ in state $s'$, obtained by solving a game defined by the current Q-functions of all agents (usually their target networks).
+
+*   **Solving for Nash Equilibrium**:
+    *   At each step requiring the target Q-value (or during action selection), the algorithm needs to construct a game for the current state (or next state $s'$).
+    *   The players in this game are all $N$ agents.
+    *   The payoff for each agent $j$ is given by its Q-function $Q_j(s', a_1, \dots, a_N)$.
+    *   A Nash Equilibrium solver (e.g., Lemke-Howson algorithm for two-player games, or other iterative methods for N-player games) is needed to find a Nash Equilibrium strategy profile $(\pi_1^*(s'), \dots, \pi_N^*(s'))$ or a pure-strategy Nash Equilibrium action profile $(a_1^*, \dots, a_N^*)$ for that state.
+    *   If a mixed-strategy Nash Equilibrium is found, the Nash Q-value is the expected Q-value under this mixed strategy.
+    *   **Challenge**: Solving for Nash Equilibrium can be computationally expensive, especially as the number of agents and actions increases. Practical implementations might use approximate solvers or assumptions about the game type (e.g., zero-sum, cooperative) to simplify this.
+
+*   **Action Selection**:
+    *   During execution, agent $i$ can also select actions based on a Nash Equilibrium analysis for the current state $s$. Alternatively, for simplification, an $\epsilon$-greedy strategy can be used, where the "greedy" part involves selecting the action that maximizes its individual Q-value, assuming other agents follow their current policies or some equilibrium strategy.
+
+*   **Experience Replay** and **Target Networks**:
+    *   Nash-DQN also employs experience replay and target networks to stabilize the learning process, similar to standard DQN.
+
+## 3. Application in Traffic Signal Control
+
+Nash-DQN is suitable for scenarios where multiple traffic signals act as interacting agents.
+
+*   **Agents**: Each intersection's traffic signal is an agent.
+*   **State (S)**:
+    *   Can be local observations for each agent (e.g., queue lengths, traffic flow, current phase at its own intersection) potentially augmented with information from neighboring intersections.
+    *   Could also be a global state encompassing all relevant intersections.
+*   **Action (A)**: The action for each traffic signal agent is to choose the next signal phase (a discrete action space).
+*   **Reward (R)**:
+    *   Can be based on local metrics (e.g., reduction in average vehicle waiting time at its own intersection).
+    *   Can also be based on global or regional metrics (e.g., reduction in total waiting time for all vehicles in an area) to promote cooperation.
+*   **Game Formulation**:
+    *   In a given state, the combination of phases chosen by each signal light leads to different systemic or local outcomes (e.g., total waiting time). These outcomes (or their Q-value estimates) form the payoff matrix for the game.
+    *   The algorithm seeks a combination of phase choices where no single traffic light can improve its (individual or common) reward by unilaterally changing its phase selection – this is the Nash Equilibrium point.
+
+## 4. Key Features and Challenges
+
+*   **Multi-Agent Coordination**: Explicitly models the strategic interactions between agents, aiming for stable joint policies.
+*   **Game Theory Foundation**: Combines reinforcement learning with the concept of Nash Equilibrium.
+*   **Applicability**: Suited for scenarios with multiple interacting decision-makers requiring decentralized or distributed control.
+*   **Computational Complexity**: Solving for Nash Equilibrium is a major bottleneck, especially with many agents or large action spaces.
+*   **Uniqueness/Multiplicity of Equilibria**: A game may have multiple Nash Equilibria, and the choice of which equilibrium to target can affect learning outcomes.
+*   **Dependence on Model Accuracy**: Although model-free RL, the game formulation relies on accurate Q-value estimates, which indirectly reflect environmental dynamics.
+
+Nash-DQN offers a theoretically sounder approach to learning in multi-agent environments, but its practical application often requires simplifications or approximations for the Nash Equilibrium computation.

--- a/Nash-QL/readme.md
+++ b/Nash-QL/readme.md
@@ -1,7 +1,66 @@
-# 步骤——把sarsa_ucb需要修改哪些文件
-1. 修改agent类中select_action函数、增加ucb函数、替换update_q_table_ql_single函数
-2. 修改yaml中参数部分
-3. 主函数根据sarsa流程进行修改
-4. 过程控制update_q_table函数修改
-5. init修改成对应的参数名称
-6. 存储数据中loss？
+# Nash-QL (Nash Q-Learning)
+
+## 1. Introduction
+
+Nash Q-Learning (Nash-QL) is a Multi-Agent Reinforcement Learning (MARL) algorithm that combines the game theory concept of Nash Equilibrium with traditional Q-Learning. In environments where multiple agents coexist and their actions are interdependent (e.g., multiple traffic signals managing traffic flow), Nash-QL aims for each agent to make decisions by considering not only its own Q-values but also the Nash Equilibrium behavior of other agents, thereby hoping to achieve a stable joint policy.
+
+Unlike single-agent Q-learning, Nash-QL explicitly addresses the non-stationarity of the environment caused by other agents' changing policies. It assumes agents interact in a shared (or partially observable) state, where each agent's rewards and state transitions can be affected by the actions of others.
+
+## 2. Method
+
+The core of Nash-QL lies in modifying the Q-value update rule of traditional Q-learning, specifically by incorporating the solution of a Nash Equilibrium when calculating the target Q-value.
+
+*   **Q-Table or Q-Function**:
+    *   In its simplest form (e.g., for small, discrete state and action spaces), each agent $i$ maintains a Q-table $Q_i(s, a_1, \dots, a_N)$, storing the expected return for agent $i$ when the joint action $(a_1, \dots, a_N)$ is taken in the joint state $s$.
+    *   For more complex state spaces, function approximation (e.g., linear functions or simple neural networks) can be used to represent $Q_i(s, \mathbf{a})$, where $\mathbf{a} = (a_1, \dots, a_N)$ is the joint action.
+
+*   **Q-Value Update**:
+    The traditional Q-learning update rule is:
+    $$
+    Q(s,a) \leftarrow Q(s,a) + lpha \left( r + \gamma \max_{a'} Q(s',a') - Q(s,a) ight)
+    $$
+    In Nash-QL, for agent $i$, the update rule for its Q-function $Q_i(s, \mathbf{a})$ becomes:
+    $$
+    Q_i(s, \mathbf{a}) \leftarrow (1-lpha)Q_i(s, \mathbf{a}) + lpha \left( r_i + \gamma 	ext{NashQ}_i(s', \mathbf{Q_1}(s', \cdot), \dots, \mathbf{Q_N}(s', \cdot)) ight)
+    $$
+    Where:
+    *   $lpha$ is the learning rate.
+    *   $r_i$ is the immediate reward received by agent $i$ after joint action $\mathbf{a}$ is taken in state $s$.
+    *   $\gamma$ is the discount factor.
+    *   $s'$ is the next state.
+    *   $	ext{NashQ}_i(s', \cdot)$ represents the Nash Equilibrium Q-value for agent $i$ in the next state $s'$. This value is derived by solving an N-player game defined by the current Q-functions (or stable versions like target Q-tables) $Q_1, \dots, Q_N$ for all agents at state $s'$. A payoff matrix (formed by Q-values for different joint actions) is constructed for state $s'$, and a Nash Equilibrium point $(a_1^*, \dots, a_N^*)$ is found. $	ext{NashQ}_i(s', \cdot)$ is then $Q_i(s', a_1^*, \dots, a_N^*)$ at this equilibrium.
+
+*   **Solving for Nash Equilibrium**:
+    *   This is a critical computational step in Nash-QL. For each next state $s'$, a stage game defined by the current Q-functions $Q_j(s', \cdot)$ of all agents $j$ must be constructed.
+    *   Algorithms like Lemke-Howson for two-player games, or more complex methods for N-player games (e.g., iterative best response, variations of fictitious play, or solvers for specific game structures) are needed to compute a Nash Equilibrium.
+    *   The computed Nash Equilibrium can be a pure strategy (each agent selects a deterministic action) or a mixed strategy (each agent selects actions probabilistically).
+    *   **Challenge**: Computing Nash Equilibria is computationally intensive, especially with many agents or large action spaces.
+
+*   **Action Selection**:
+    *   During learning, agent $i$ selects action $a_i$ in the current state $s$ using an $\epsilon$-greedy strategy.
+    *   The "greedy" part involves selecting the action that maximizes its Q-value within the Nash Equilibrium computed for state $s$. This also requires solving for a Nash Equilibrium.
+    *   Alternatively, for simplification, individual Q-value maximization can be used, assuming other agents follow fixed or learned policies.
+
+## 3. Application in Traffic Signal Control
+
+Nash-QL can be applied to control multiple interdependent traffic signals.
+
+*   **Agents**: Each intersection's traffic signal is an independent agent.
+*   **State (S)**: Can be the local state of each intersection (e.g., queue lengths, waiting vehicles, current phase) or a combined state including information from neighboring intersections.
+*   **Action (A)**: The action for each agent (signal) is to choose the next signal phase (typically discrete).
+*   **Reward (R)**:
+    *   Can be designed as a local reward (e.g., based on waiting time reduction at its own intersection).
+    *   Can also be a global reward or one that considers neighborhood impact, to foster cooperation or manage competition, depending on the game setup (e.g., fully cooperative, fully competitive, or general-sum game).
+*   **Game Model**:
+    *   At each decision point, each signal chooses an action (phase). The combination of these actions jointly determines the next state of the overall (or local) traffic system and the reward each signal receives.
+    *   Nash-QL attempts to find a stable combination of phase selection strategies such that no signal can unilaterally change its phase choice to improve its expected return (in the equilibrium sense).
+
+## 4. Key Features and Challenges
+
+*   **Multi-Agent Decision Making**: Explicitly models the strategic interdependencies among agents.
+*   **Game Theory Foundation**: Central to the algorithm is the integration of Q-learning with Nash Equilibrium computation.
+*   **Convergence**: Convergence of Nash-QL is more challenging to guarantee than single-agent Q-learning. It may converge to any of multiple Nash Equilibria or, in some cases (especially in general-sum games with function approximation), may not converge.
+*   **Computational Cost**: The computation of Nash Equilibria is the primary bottleneck, particularly for systems with many agents and complex action spaces.
+*   **Information Requirement**: To solve for Nash Equilibrium, an agent might need to know the Q-functions (or at least the actions or policies) of other agents, which can pose communication or observability challenges.
+
+Nash-QL provides a robust theoretical framework for addressing cooperation and competition in multi-agent environments. However, its practical application in complex systems like large traffic networks often necessitates simplifications, such as using approximate Nash Equilibrium solvers or applying it to smaller clusters of agents.

--- a/SARSA_UCB/SARSA_UCB/readme.md
+++ b/SARSA_UCB/SARSA_UCB/readme.md
@@ -1,5 +1,81 @@
-# 步骤——把sarsa_ucb需要修改哪些文件
-1. 修改agent类中select_action函数、增加ucb函数、替换update_q_table_ql_single函数
-2. 修改yaml中参数部分
-3. 主函数根据sarsa流程进行修改
-4. 过程控制update_q_table函数修改
+# SARSA with UCB (SARSA-UCB)
+
+## 1. Introduction
+
+SARSA (State-Action-Reward-State-Action) is an on-policy, online Temporal Difference (TD) reinforcement learning algorithm. It directly learns an action-value function, Q(s,a), which represents the expected return for taking action 'a' in state 's' and thereafter following the current policy.
+
+UCB (Upper Confidence Bound) is a classic exploration-exploitation balancing strategy, commonly used in multi-armed bandit problems. It encourages trying out arms (or actions) with high uncertainty or those that have been explored less frequently by adding a confidence bonus to their value estimates.
+
+SARSA-UCB combines these two ideas: it uses SARSA as the primary learning update rule and employs a UCB-based strategy for action selection to effectively balance exploration and exploitation during the learning process.
+
+## 2. Method
+
+*   **SARSA Update Rule**:
+    The core of SARSA is its Q-value update formula. After an agent takes action $a$ in state $s$, receives reward $r$, transitions to a new state $s'$, and then selects action $a'$ in $s'$ according to its current policy, the Q-value $Q(s,a)$ is updated as follows:
+    $$
+    Q(s,a) \leftarrow Q(s,a) + lpha \left[ r + \gamma Q(s',a') - Q(s,a) ight]
+    $$
+    Where:
+    *   $lpha$ is the learning rate.
+    *   $\gamma$ is the discount factor.
+    *   The tuple $(s, a, r, s', a')$ gives SARSA its name. Because the update depends on the next state $s'$ and the next action $a'$ that will actually be taken in $s'$, it is an on-policy algorithm—it evaluates the policy it is currently executing.
+
+*   **UCB Action Selection**:
+    When selecting an action in state $s$, SARSA-UCB uses a UCB1-like approach instead of simple random exploration (like $\epsilon$-greedy). For each possible action $a_i$ in state $s$, a UCB value is calculated:
+    $$
+	ext{UCB}(s, a_i) = Q(s, a_i) + C \sqrt{rac{\ln N(s)}{N(s, a_i)}}
+    $$
+    The action with the highest UCB value is then chosen:
+    $$
+    a = rg\max_{a_i} 	ext{UCB}(s, a_i)
+    $$
+    Where:
+    *   $Q(s, a_i)$ is the current estimate of the value of taking action $a_i$ in state $s$.
+    *   $N(s)$ is the total number of times state $s$ has been visited (or the total number of decisions made so far).
+    *   $N(s, a_i)$ is the number of times action $a_i$ has been selected in state $s$.
+    *   $C$ is a positive constant, known as the exploration constant, which controls the degree of exploration: a larger $C$ encourages more exploration.
+
+    **Handling $N(s, a_i) = 0$**: If an action $a_i$ has never been tried in state $s$ (i.e., $N(s, a_i)=0$), its UCB value is typically treated as infinite, ensuring it gets selected to encourage initial exploration of all actions.
+
+    The UCB policy encourages exploration through its second term (the confidence bound). If an action has been chosen infrequently ($N(s, a_i)$ is small), or if the state $s$ has been visited many times ($N(s)$ is large), this term increases, thereby boosting the probability of that action being selected.
+
+*   **Algorithm Flow**:
+    1.  Initialize Q(s,a) table (e.g., to zeros or optimistically). Initialize $N(s)$ and $N(s,a)$ counters to 0.
+    2.  Get the initial state $s$.
+    3.  Select action $a$ from state $s$ using the UCB policy.
+    4.  **Loop** (until terminal state or max steps):
+        a.  Take action $a$, observe reward $r$ and new state $s'$.
+        b.  Select next action $a'$ from state $s'$ using the UCB policy.
+        c.  Update $Q(s,a)$: $Q(s,a) \leftarrow Q(s,a) + lpha \left[ r + \gamma Q(s',a') - Q(s,a) ight]$.
+        d.  Increment counters: $N(s) \leftarrow N(s) + 1$, $N(s,a) \leftarrow N(s,a) + 1$.
+        e.  $s \leftarrow s'$, $a \leftarrow a'$.
+    5.  **End** loop.
+
+## 3. Application in Traffic Signal Control
+
+SARSA-UCB can be used to learn control policies for traffic signals.
+
+*   **State (S)**:
+    *   Typically a discretized representation of the traffic state, e.g., by categorizing queue lengths, vehicle arrival rates, etc., into several levels.
+    *   Can also include the current signal phase, elapsed time in the phase, etc.
+    *   Since UCB requires counts of state visits and state-action pair visits, highly continuous or high-dimensional state spaces might need state aggregation or function approximation, which complicates the direct application of UCB. If a Q-table is used directly, states must be discrete.
+
+*   **Action (A)**:
+    *   A discrete set of actions, such as selecting the next signal phase to activate or deciding whether to extend the current phase.
+
+*   **Reward (R)**:
+    *   Designed to reflect traffic efficiency, e.g., based on changes in waiting time, queue length, or throughput.
+
+*   **Q-function and Counters**:
+    *   For small state and action spaces, $Q(s,a)$, $N(s)$, and $N(s,a)$ can be stored in tabular form.
+    *   For larger state spaces, function approximators might be needed for $Q(s,a)$, but accurately maintaining UCB counters $N(s)$ and $N(s,a)$ becomes difficult and may require hash-based approximate counting or other techniques.
+
+## 4. Key Features and Considerations
+
+*   **On-Policy**: SARSA learns the value of the policy it is currently executing, including its exploration steps.
+*   **Exploration Mechanism**: UCB provides a more sophisticated exploration mechanism than $\epsilon$-greedy, guiding exploration based on uncertainty and favoring less-tried actions that have higher potential.
+*   **Convergence**: SARSA is guaranteed to converge to the optimal policy under certain conditions (e.g., appropriate decay of the learning rate, infinite visits to all state-action pairs). UCB helps in systematically exploring these pairs.
+*   **Sensitivity to Parameter C**: The exploration constant C in UCB significantly impacts performance and requires careful tuning.
+*   **State/Action Space Size**: Traditional tabular SARSA-UCB is primarily suitable for small to medium-sized discrete state and action spaces. For larger problems, integration with function approximation is necessary, which can complicate the theoretical guarantees and implementation of UCB.
+
+SARSA-UCB, by combining SARSA's online learning capability with UCB's intelligent exploration strategy, offers an effective solution for reinforcement learning problems, especially in scenarios requiring a careful balance between exploration and exploitation.


### PR DESCRIPTION
I replaced previously added Chinese supplementary content with English explanations for the following algorithm README.md files:

- Actor-Critic(AC)_boltzmann/readme.md
- DDPG/readme.md
- DuelingDDQN-DNN(D3QN)/readme.md
- Nash-DQN/readme.md
- Nash-QL/readme.md
- SARSA_UCB/SARSA_UCB/readme.md

I ensured all supplementary algorithm descriptions detailing methodologies, traffic control applications, and key characteristics are now in English as per your request.